### PR TITLE
Add Prefix Sum

### DIFF
--- a/data_structures/arrays/PrefixSum.swift
+++ b/data_structures/arrays/PrefixSum.swift
@@ -1,0 +1,91 @@
+//
+//  PrefixSum.swift
+//
+//
+//  Created by Moon Jongseek(Rey) on 11/10/24.
+//
+
+import Foundation
+
+/// A class representing a prefix sum.
+///
+/// The type of the elements in the sequence, constrained to types that conform to
+/// `AdditiveArithmetic` and `Hashable` such as `Int` and`Double`.
+final class PrefixSum<T: AdditiveArithmetic & Hashable> {
+    /// Origin Array.
+    public var array: [T]
+    /// The Prefix Sum Array.
+    public var prefixSum: [T]
+    
+    /// Initializes a new prefix sum with the array.
+    ///
+    /// - Parameters:
+    ///   - array: The array with `AdditiveArithmetic` & `Hashable` type data.
+    init(array: [T]) {
+        let length = array.count
+        self.array = array
+        self.prefixSum = Array(repeating: T.zero, count: length)
+        if length > 0 {
+            self.prefixSum[0] = array[0]
+            for i in 1..<length {
+                self.prefixSum[i] = self.prefixSum[i-1] + array[i]
+            }
+        }
+    }
+    
+    /// The function returns the sum of array from the start to the end indexes.
+    ///
+    /// The following example shows a specified range sum for the `Int` type:
+    ///
+    ///     let prefixSum = PrefixSum<Int>(array: [8,3,4,2,6,7])
+    ///     prefixSum.getSum(start: 0, end: 3)
+    ///     // 17
+    ///     prefixSum.getSum(start: -1, end: 3)
+    ///     // nil
+    ///
+    /// - Parameters:
+    ///   - start: The starting index of the range for the sum calculation.
+    ///   - end: The ending index of the range for the sum calculation (inclusive).
+    ///
+    /// - Returns: The sum of elements from `start` to `end` as an optional value of type `T`.
+    ///   Returns `nil` if the range is invalid or out of bounds.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public func getSum(start: Int, end: Int) -> T? {
+        let length = array.count
+        guard (0..<length ~= start) && (0..<length ~= end) && (start <= end) else {
+            return nil
+        }
+        return self.prefixSum[end] - (start == 0 ? T.zero : self.prefixSum[start - 1])
+    }
+    
+    /// Checks if there exists a contiguous subarray with a sum equal to the target value.
+    ///
+    /// The following example shows how to check for the presence of
+    /// a specified target sum within a contiguous subarray for the `Int` type:
+    ///
+    ///     let prefixSum = PrefixSum<Int>(array: [8,3,4,2,6,7])
+    ///     prefixSum.containsSum(targetSum: 9)
+    ///     // true
+    ///     prefixSum.containsSum(targetSum: 31)
+    ///     // false
+    ///
+    /// - Parameters:
+    ///   - targetSum: The target sum to check for within the prefix sums.
+    ///
+    /// - Returns: `true` if there is a contiguous subarray with a sum equal to `targetSum`; otherwise, `false`.
+    ///
+    /// - Complexity: O(n)
+    ///
+    public func containsSum(targetSum: T) -> Bool {
+        var sumSet: Set<T> = [T.zero]
+        for sumItem in self.prefixSum {
+            if sumSet.contains(sumItem - targetSum) {
+                return true
+            }
+            sumSet.insert(sumItem)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
# Prefix Sum

# Description
This is a Prefix Sum implementation in Swift.
The code provides the same performance and functionality as the Python code below.
[Prefix Sum in Python](https://github.com/TheAlgorithms/Python/blob/master/data_structures/arrays/prefix_sum.py)

Additionally, it returns `nil` when the values of `start` and `end` are not within a valid index range.
``` swift
guard (0..<length ~= start) && (0..<length ~= end) && (start <= end) else {
    return nil
}
```

I have declared it as a generic type.

To enable the use of the `+` operation and the `Set`,
I have restricted it to types that adopt the `AdditiveArithmetic` and `Hashable` protocols.

The comments are written in the style of Apple Developer Documentation.
This is the first PR for this repository. I appreciate your consideration.🙇‍♂️

# Code

``` swift
final class PrefixSum<T: AdditiveArithmetic & Hashable> {
    public var array: [T]
    public var prefixSum: [T]

    init(array: [T]) {
        let length = array.count
        self.array = array
        self.prefixSum = Array(repeating: T.zero, count: length)
        if length > 0 {
            self.prefixSum[0] = array[0]
            for i in 1..<length {
                self.prefixSum[i] = self.prefixSum[i-1] + array[i]
            }
        }
    }

    public func getSum(start: Int, end: Int) -> T? {
        let length = array.count
        guard (0..<length ~= start) && (0..<length ~= end) && (start <= end) else {
            return nil
        }
        return self.prefixSum[end] - (start == 0 ? T.zero : self.prefixSum[start - 1])
    }

    public func containsSum(targetSum: T) -> Bool {
        var sumSet: Set<T> = [T.zero]
        for sumItem in self.prefixSum {
            if sumSet.contains(sumItem - targetSum) {
                return true
            }
            sumSet.insert(sumItem)
        }
        return false
    }
}
```